### PR TITLE
Chore/k8s manifests

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -195,3 +195,59 @@ spec:
   - port: 8082
     name: "8082"
     targetPort: 8082
+---
+################################################################################
+# ISTIO INGRESS GATEWAY
+# Istio already handles the internal routing/dns, this exposes specific services
+# to the web.
+################################################################################
+apiVersion: networking.istio.io/v1beta1
+kind: Gateway
+metadata:
+  name: iot-gateway
+spec:
+  selector:
+    istio: ingress
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "*"
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: iot-service-routing
+spec:
+  hosts:
+  - "*"
+  gateways:
+  - iot-gateway
+  # double the matching URIs to properly handle rewriting to root on the destination services
+  http:
+  - match:
+    - uri:
+        prefix: /iot/sensor-api/
+    - uri:
+        exact: /iot/sensor-api
+    rewrite:
+      uri: /
+    route:
+    - destination:
+        port:
+          number: 8080
+        host: api
+  - match:
+    - uri:
+        exact: /iot/
+    - uri:
+        exact: /iot
+    rewrite:
+      uri: /
+    route:
+    - destination:
+        port:
+          number: 80
+        host: app


### PR DESCRIPTION
This PR adds the Kubernetes manifests for the App, Api, Real Fake Sensors, and Sensational Sensors. Additionally, supporting services for the Istio service mesh and ingress are established.

## 🏋️ Changes

- 🚀 Added Kubernetes manifests for:
  - Application (deployment, service, Istio virtual service)
  - Api (deployment, service, Istio virtual service)
  - Real Fake sensors (deployment, service)
  - Sensational sensors (deployment, service) 
  - IOT Gateway (exposes the App and API virtual services and does some rudimentary routing)

## 🧪 To test

This deployment uses the [Istio Ingress](https://console.cloud.google.com/kubernetes/service/northamerica-northeast1-a/example-private-cluster/istio-ingress/istio-ingress/overview?project=k8s-sandbox-388415) load balancer on the cluster, which currently exposes http://35.203.112.8/ on port 80. 

1. Navigate to the Api endpoint [http://35.203.112.8/iot/sensor-api/](http://35.203.112.8/iot/sensor-api/). You should get a `preformatted` display of `{"detail":"Not Found"}`, this is the **API server's** 404 response, which means it's responding!
2. Navigate to the `/sensors` route on the Api endpoint [http://35.203.112.8/iot/sensor-api/sensors](http://35.203.112.8/iot/sensor-api/sensors). You should get some JSON of the sensor data.
3. Navigate to the App endpoint [http://35.203.112.8/iot/](http://35.203.112.8/iot/). The application should display.
> **Note:** There is currently a bug with environment variables, causing the Application to attempt to connect to the Api internally via `http://app:8080` rather than the exposed `http://35.203.112.8/iot/sensor-api/`. This will be addressed in a subsequent PR (ToBeDetermined).

## 🚅 Notes for the future

Since we don't have an associated hostname for now, I've exposed it on the `/iot` route on the load balancer. When there is a hostname to attach to, we can alter the manifest for the Istio _virtual services_  and _gateway_ to take advantage of it. 

## 🤔 Additional info

### 🌱 Deployment process

These manifests are currently _manually_ applied using the following method:

0. Authenticate and connect to the namespace with the `./connect.sh` script from [button-inc/k8s-cluster at task-738 (github.com)](https://github.com/button-inc/k8s-cluster/tree/task-738)
1. Create a namespace: `kubectl create ns iot`.
2. Apply the Istio label to enable sidecar creation (easier networking, yay ⛵): `kubectl label namespace iot istio-injection=enabled`.
3. Create the deploy secret *in that namespace*: `kubectl create secret docker-registry ghcr-login-secret --docker-server=https://ghcr.io --docker-username=GITHUB_USERNAME --docker-password=ghp_PERSONAL_ACCESS_TOKEN_KEY -n iot`.
   - This personal access token needs package read permissions when created. See the [GitHub Docs to creat one](https://docs.github.com/en/enterprise-server@3.6/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token). In this case, I've used a PAT that I created and my username. 
   - When this deployment is automated, we'll likely want to use a GitHub Secret instead, [more info here](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow).
5. Deploy the manifest to the namespace: `kubectl apply -f ./manifest.yaml -n iot`.

### 🧜‍♀️ Manifest diagram

Here's a graphic showing the components we create (squared nodes) and how they're connected, vaugley. 
```mermaid
flowchart TD
    subgraph iot ["iot" namespace in cluster]
        iG[_Istio_ gateway] <--> VS[_Istio_ virtual service]
        subgraph App [Application]
            AppS[service] --> AppD[deployment]
        end
        subgraph Api [API]
            ApiS[service] --> ApiD[deployment]
        end
        subgraph RFs [Real Fake sensors]
            RFsS[service] --> RFsD[deployment]
        end
        subgraph Ss [Sensational sensors]
            SsS[service] --> SsD[deployment]
        end
        Api -.in-cluster traffic.-> RFs
        Api -.in-cluster traffic.-> Ss
        VS --> AppS
        VS --> ApiS
    end
    subgraph cluster
        iot
        iI([Cluster-wide Istio Ingress])
    end
    www((Public internet client)) -.external traffic.-> iI --> iG
```