### PR TITLE
fixing small issue with filter count for when user clears a filter

### DIFF
--- a/app_vue/src/components/sensorSideBarFilters.vue
+++ b/app_vue/src/components/sensorSideBarFilters.vue
@@ -80,7 +80,11 @@
     sensorStore.setSelectedGroup(state.selectedGroup);
     updateSensorsShown();
 
-    state.filterEnabledMap['group'] = true;
+    if (state.selectedGroup) {
+      state.filterEnabledMap['group'] = true;
+    } else {
+      state.filterEnabledMap['group'] = false;
+    }
   }
 
   function updateAssetTagFilter() {
@@ -109,7 +113,11 @@
     sensorStore.setSelectedBinVolume(state.selectedBinVolume);
     updateSensorsShown();
 
-    state.filterEnabledMap['binVolume'] = true;
+    if (state.selectedBinVolume) {
+      state.filterEnabledMap['binVolume'] = true;
+    } else {
+      state.filterEnabledMap['binVolume'] = false;
+    }
   }
 
   function updateFillRangeFilter() {


### PR DESCRIPTION
Fixing this issue for single select filters where the filter count isnt being properly updated.
To recreate issue:
1. a filter is selected
  - <img width="227" alt="image" src="https://github.com/button-inc/iot-system-prototype/assets/7142197/9ae7cfc3-d5f1-43b3-93e8-9cb0256f7f28">

2. filter is cleared
3. filter count is NOT updated (still shows 1)
  - <img width="220" alt="image" src="https://github.com/button-inc/iot-system-prototype/assets/7142197/35676dc6-7550-4427-9c7a-db98bd9d89b0">