### PR TITLE
small spacing tweak

### DIFF
--- a/app_vue/src/components/sensorSideBarFilters.vue
+++ b/app_vue/src/components/sensorSideBarFilters.vue
@@ -251,7 +251,7 @@
     </section>
 
 
-    <div class="my-6">
+    <div class="mb-6">
       <span class="font-weight-bold">Result: {{ state.totalSensors }} bin{{ state.totalSensors > 1 ? 's' : '' }}</span>
       displayed on map
     </div>
@@ -285,6 +285,10 @@
   .filter-list {
     width: 100%;
 
+    &__fields {
+      margin-bottom: 20px;
+    }
+    
     &__heading {
       display: flex;
       align-items: center;


### PR DESCRIPTION
just a small css change to remove a huge gap when the filters are collapsed:
<img width="339" alt="image" src="https://github.com/button-inc/iot-system-prototype/assets/7142197/1db9fda1-a39b-438f-b5c9-c613d6f06051">
