### PR TITLE
small spacing tweaks for sidebar

### DIFF
--- a/app_vue/src/components/sensorSideBarFilters.vue
+++ b/app_vue/src/components/sensorSideBarFilters.vue
@@ -170,7 +170,7 @@
 <template>
   <section class="filter-list">
     <div class="filter-list__heading">
-      <div class="align-center">
+      <div class="d-flex align-center">
         <span class="filter-list__title">Filter ({{ getFilterCount() }})</span> 
         <span class="mx-3">|</span>
         <v-btn variant="plain" color="#2196F3" class="pa-0 pt-1 text-capitalize" @click="clearFilters">Clear</v-btn>
@@ -308,10 +308,6 @@
 
     &__label {
       @include fontBody;
-    }
-
-    &__title {
-      min-width: 164px;
     }
 
     .v-btn {

--- a/app_vue/src/components/sensorSideBarFilters.vue
+++ b/app_vue/src/components/sensorSideBarFilters.vue
@@ -292,7 +292,7 @@
     &__heading {
       display: flex;
       align-items: center;
-      padding-bottom: 30px;
+      padding-bottom: 24px;
       justify-content: space-between;
       flex-direction: column;
       @include fontHeading6;

--- a/app_vue/src/components/sensorSidebar.vue
+++ b/app_vue/src/components/sensorSidebar.vue
@@ -96,7 +96,7 @@
     min-width: 204px;
     width: 100%;
     justify-content: flex-start;
-    padding: 24px 0 0 0;
+    padding: 28px 0 0 0;
     @include fontBodySmall;
 
     &__icon {

--- a/app_vue/src/components/sensorSidebar.vue
+++ b/app_vue/src/components/sensorSidebar.vue
@@ -96,7 +96,7 @@
     min-width: 204px;
     width: 100%;
     justify-content: flex-start;
-    padding-left: 0;
+    padding: 24px 0 0 0;
     @include fontBodySmall;
 
     &__icon {


### PR DESCRIPTION
spacing items a little more evenly in sidebar (css change)

result:
<img width="352" alt="image" src="https://github.com/button-inc/iot-system-prototype/assets/7142197/81eb0261-9f97-4b67-90f4-a782b1c38287">

<img width="357" alt="image" src="https://github.com/button-inc/iot-system-prototype/assets/7142197/eddbb9e5-d433-4c09-b7fc-0cc812dd2b42">
