### PR TITLE
adding alerts and last collected date to bin popup

### DIFF
--- a/app_vue/src/assets/stylesheets/_functions.scss
+++ b/app_vue/src/assets/stylesheets/_functions.scss
@@ -54,7 +54,7 @@
 }
 
 .color-green {
-  color: #009E08;
+  color: #2B8000;
 }
 
 .color-red {

--- a/app_vue/src/assets/stylesheets/_mixins.scss
+++ b/app_vue/src/assets/stylesheets/_mixins.scss
@@ -64,7 +64,7 @@
 
 @mixin fontSubTitle2() {
   font-size: 0.875rem;
-  font-weight: 500;
+  font-weight: 400;
   line-height: 1.375rem;
   letter-spacing: 0.0071428571em;
   font-family: $font-face;  

--- a/app_vue/src/assets/stylesheets/_variables.scss
+++ b/app_vue/src/assets/stylesheets/_variables.scss
@@ -7,3 +7,4 @@ $grey: #8D8D8D;
 $red: #C92828;
 $lightergrey: #D9D9D9;
 $cyanBlue: #2196F3;
+$green: #2B8000;

--- a/app_vue/src/components/sensorMapMarker.vue
+++ b/app_vue/src/components/sensorMapMarker.vue
@@ -291,6 +291,7 @@
       &__title {
         margin-bottom: 6px;
         color: $grey;
+        @include fontSubTitle2;
       }
 
       &__item {
@@ -305,10 +306,12 @@
       flex-direction: column;
       flex: 1;
       align-items: center;
+      
       &__title {
         margin-bottom: 6px;
         color: $grey;
         text-align: center;
+        @include fontSubTitle2;
       }
 
       &__item {

--- a/app_vue/src/components/sensorMapMarker.vue
+++ b/app_vue/src/components/sensorMapMarker.vue
@@ -284,6 +284,7 @@
     flex: 1;
     gap: 20px;
     margin-top: 6px;
+    width: 100%;
     .alerts {
       display: flex;
       flex-direction: column;
@@ -303,7 +304,7 @@
       display: flex;
       flex-direction: column;
       flex: 1;
-
+      align-items: center;
       &__title {
         margin-bottom: 6px;
         color: $grey;

--- a/app_vue/src/components/sensorMapMarker.vue
+++ b/app_vue/src/components/sensorMapMarker.vue
@@ -4,6 +4,7 @@
   import { useRouteStore } from '@/stores/route_store';
   import { storeToRefs } from 'pinia';
   import { getIconAndProgressColor, getMaterialTypeIconURL } from '@/utils/mapMarkerHelper';
+  import { getDate12HrTime } from '@/utils/formattingHelper';
 
   const props = defineProps({
     sensor: {
@@ -104,11 +105,41 @@
 
         <div class="material-type">
           <v-img class="material-type__image" :src="getMaterialTypeIconURL(props.sensor.material_type)" width="40" height="40" />
-          <!-- <img class="material-type__image" :src="getMaterialTypeIconURL(props.sensor.material_type)"/> -->
           <span class="material-type__description">{{ props.sensor.material_type }}</span>
         </div>
       </section>
     </div>
+
+    <section class="alerts-section">
+      <div class="alerts">
+        <div class="alerts__title">
+          <span>Alerts Set</span>
+        </div>
+        <div class="alerts__item" v-if="props.sensor.fill_level_alert">
+          <vue-feather size="18" class="color-green mr-2" type="bell"></vue-feather>
+          <span>Fill-level > {{ props.sensor.fill_level_alert }}%</span>
+        </div>
+        <div class="alerts__item" v-if="props.sensor.temperature_alert">
+          <vue-feather size="18" class="color-green mr-2" type="bell"></vue-feather>
+          <span>Temperature > {{props.sensor.temperature_alert}}&deg;C</span>
+        </div>
+        <div class="alerts__item" v-if="props.sensor.illegal_dumping_alert">
+          <vue-feather size="18" class="color-green mr-2" type="bell"></vue-feather>
+          <span>Illegal dumping</span>
+        </div>
+        <div class="alerts__item" v-if="props.sensor.contamination_alert">
+          <vue-feather size="18" class="color-green mr-2" type="bell"></vue-feather>
+          <span>Contamination</span>
+        </div>
+      </div>
+      <div class="last-collected" v-if="props.sensor.last_collected">
+        <span class="last-collected__title">Last Collected</span>
+        <div class="last-collected__item">
+          <span>{{ getDate12HrTime(props.sensor.last_collected)}}</span>
+          <span>at 100% full</span> 
+        </div>
+      </div>
+    </section>
 
 
     <!-- add to route buttons -->
@@ -244,6 +275,48 @@
     &__cta-routes,
     &__cta-routes button {
       width: 100%;
+    }
+  }
+
+  .alerts-section {
+    display: flex;
+    align-items: flex-start;
+    flex: 1;
+    gap: 20px;
+    margin-top: 6px;
+    .alerts {
+      display: flex;
+      flex-direction: column;
+      &__title {
+        margin-bottom: 6px;
+        color: $grey;
+      }
+
+      &__item {
+        display: flex;
+        align-items: center;
+        padding-bottom: 2px;
+      }
+    }
+
+    .last-collected {
+      display: flex;
+      flex-direction: column;
+      flex: 1;
+
+      &__title {
+        margin-bottom: 6px;
+        color: $grey;
+        text-align: center;
+      }
+
+      &__item {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        max-width: 86px;
+        text-align: center;
+      }
     }
   }
 </style>

--- a/app_vue/src/components/sensorMapMarker.vue
+++ b/app_vue/src/components/sensorMapMarker.vue
@@ -135,8 +135,10 @@
       <div class="last-collected" v-if="props.sensor.last_collected">
         <span class="last-collected__title">Last Collected</span>
         <div class="last-collected__item">
-          <span>{{ getDate12HrTime(props.sensor.last_collected)}}</span>
-          <span>at 100% full</span> 
+          <span>{{ getDate12HrTime(props.sensor.last_collected) }}</span>
+          <span v-if="props.sensor.fill_level_last_collected">
+            at {{ props.sensor.fill_level_last_collected }}% full
+          </span> 
         </div>
       </div>
     </section>
@@ -306,7 +308,7 @@
       flex-direction: column;
       flex: 1;
       align-items: center;
-      
+
       &__title {
         margin-bottom: 6px;
         color: $grey;

--- a/app_vue/src/utils/formattingHelper.js
+++ b/app_vue/src/utils/formattingHelper.js
@@ -13,3 +13,19 @@ export const getMinutesString = (stringSeconds) => {
 export const getKmFromMeterString = (meters) => {
   return (meters / 1000).toFixed(0);
 };
+
+export const getDate12HrTime = (dateTimeStr) => {
+  // param: 2023-09-25T08:45:00
+  // return: Sep 25 2023 8:45 AM
+  return new Date(dateTimeStr).toLocaleTimeString('en-us', 
+    { 
+      year: "numeric", 
+      month: "short", 
+      day: "numeric", 
+      hour12: true, 
+      hour: '2-digit', 
+      minute: '2-digit', 
+      timezone: "UTC"
+    })
+    .replaceAll(',', '');
+};


### PR DESCRIPTION
updating bin popup with "alerts" section and "last collected date" section:
Wireframe: https://www.figma.com/file/HoNLIsd3czlpYWPcdtyQPt/WAVsmart-Wireframes?type=design&node-id=1370-15179&mode=design&t=xzalnBDpi1qqO03q-4

Actual in local:
<img width="351" alt="image" src="https://github.com/button-inc/iot-system-prototype/assets/7142197/cfce9056-414b-4b31-9103-60fba7d44bc1">


**how:**
- only displaying values if alerts are set
- formatting date of last collected date BE value to match design
- we utilized the following new backend structure:
  - note that fill level alert value is from backend data
  - note that temperature alert value is from backend data
  - note that fill level last collected percentage is from backend data
```
{
  "id": 15,
  "row_id": 17,
  "bin_name": "International centre 95gal tote",
  "address_line1": "6900 Airport Rd.",
  "address_line2": null,
  "city": "Mississauga",
  "province": "ON",
  "postal_code": "L4V 1E8",
  "lat": 43.704336,
  "long": -79.635111,
  "bin_volume": "95 gal",
  "bin_type": "Tote",
  "material_type": "Mixed Containers",
  "asset_tag": "Office",
  "group": "Central",
  "fill_level": 45,
  "fill_level_alert": 75,
  "temperature_alert": 85,
  "illegal_dumping_alert": false,
  "contamination_alert": false,
  "last_collected": "2023-09-25T08:45:00"
}
```

